### PR TITLE
複数 txt ファイルの読み込み・並び替え機能を追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,23 +1,48 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { FloatingActions } from "./components/FloatingActions";
 import { ScriptSummary } from "./components/ScriptSummary";
 import { ScriptView } from "./components/ScriptView";
 import { toggleCharactersByMatch } from "./lib/characterToggle";
 import { isHighlighted } from "./lib/dialogue";
 import { buildDialogueText, exportFileName } from "./lib/exportDialogue";
-import { parseScript, type ParseWarning } from "./lib/parseScript";
+import {
+  combineContents,
+  deriveTitle,
+  moveFile,
+  removeFile,
+} from "./lib/loadedFiles";
+import { parseScript } from "./lib/parseScript";
 import { toggleInSet } from "./lib/setOps";
-import type { Dialogue } from "./types";
+import type { LoadedFile } from "./types";
+
+function readFileAsText(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const result = e.target?.result;
+      if (typeof result === "string") resolve(result);
+      else reject(new Error("read failed"));
+    };
+    reader.onerror = () => reject(reader.error ?? new Error("read failed"));
+    reader.readAsText(file, "UTF-8");
+  });
+}
 
 export function App() {
   const [title, setTitle] = useState("");
-  const [fileLoaded, setFileLoaded] = useState(false);
-  const [dialogues, setDialogues] = useState<Dialogue[]>([]);
-  const [characters, setCharacters] = useState<string[]>([]);
+  const [files, setFiles] = useState<LoadedFile[]>([]);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [noVoice, setNoVoice] = useState<Set<number>>(new Set());
-  const [warnings, setWarnings] = useState<ParseWarning[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const nextId = useRef(0);
+
+  const { dialogues, characters, warnings } = useMemo(
+    () =>
+      files.length
+        ? parseScript(combineContents(files))
+        : { dialogues: [], characters: [], warnings: [] },
+    [files],
+  );
 
   useEffect(() => {
     if (title) document.title = title;
@@ -41,28 +66,49 @@ export function App() {
     [dialogues, selected, noVoice],
   );
 
-  const onFile = (file: File) => {
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      const result = e.target?.result;
-      if (typeof result !== "string") {
-        setError("ファイルの読み込みに失敗いたしました");
-        return;
-      }
-      const { dialogues, characters, warnings } = parseScript(result);
-      setTitle(file.name);
-      setDialogues(dialogues);
-      setCharacters(characters);
+  const readFiles = async (fileList: FileList): Promise<LoadedFile[]> =>
+    Promise.all(
+      Array.from(fileList).map(async (file) => ({
+        id: nextId.current++,
+        name: file.name,
+        content: await readFileAsText(file),
+      })),
+    );
+
+  // 最初の読み込み（全置き換え）。選択・ボイス不要はリセットする
+  const loadFiles = async (fileList: FileList) => {
+    try {
+      const loaded = await readFiles(fileList);
+      setFiles(loaded);
+      setTitle(deriveTitle(loaded));
       setSelected(new Set());
       setNoVoice(new Set());
-      setWarnings(warnings);
-      setFileLoaded(true);
       setError(null);
-    };
-    reader.onerror = () => {
+    } catch {
       setError("ファイルの読み込みに失敗いたしました");
-    };
-    reader.readAsText(file, "UTF-8");
+    }
+  };
+
+  // 追加読み込み（末尾に連結）。既存セリフの id は不変なのでボイス不要は維持
+  const addFiles = async (fileList: FileList) => {
+    try {
+      const loaded = await readFiles(fileList);
+      setFiles((prev) => [...prev, ...loaded]);
+      setError(null);
+    } catch {
+      setError("ファイルの読み込みに失敗いたしました");
+    }
+  };
+
+  // 並び替え・削除は id がずれるためボイス不要をリセットする
+  const handleMove = (id: number, dir: -1 | 1) => {
+    setFiles((prev) => moveFile(prev, id, dir));
+    setNoVoice(new Set());
+  };
+
+  const handleRemove = (id: number) => {
+    setFiles((prev) => removeFile(prev, id));
+    setNoVoice(new Set());
   };
 
   const toggleCharacter = (target: string) => {
@@ -88,9 +134,12 @@ export function App() {
     <>
       <ScriptSummary
         title={title}
-        fileLoaded={fileLoaded}
+        files={files}
         onTitleChange={setTitle}
-        onFile={onFile}
+        onLoadFiles={loadFiles}
+        onAddFiles={addFiles}
+        onRemoveFile={handleRemove}
+        onMoveFile={handleMove}
         characters={characters}
         selected={selected}
         onToggleCharacter={toggleCharacter}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,8 +8,8 @@ import { buildDialogueText, exportFileName } from "./lib/exportDialogue";
 import {
   combineContents,
   deriveTitle,
-  moveFile,
   removeFile,
+  reorderFiles,
 } from "./lib/loadedFiles";
 import { parseScript } from "./lib/parseScript";
 import { toggleInSet } from "./lib/setOps";
@@ -101,8 +101,8 @@ export function App() {
   };
 
   // 並び替え・削除は id がずれるためボイス不要をリセットする
-  const handleMove = (id: number, dir: -1 | 1) => {
-    setFiles((prev) => moveFile(prev, id, dir));
+  const handleReorder = (id: number, insertBefore: number) => {
+    setFiles((prev) => reorderFiles(prev, id, insertBefore));
     setNoVoice(new Set());
   };
 
@@ -139,7 +139,7 @@ export function App() {
         onLoadFiles={loadFiles}
         onAddFiles={addFiles}
         onRemoveFile={handleRemove}
-        onMoveFile={handleMove}
+        onReorderFile={handleReorder}
         characters={characters}
         selected={selected}
         onToggleCharacter={toggleCharacter}

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -1,47 +1,70 @@
+import { useState } from "react";
 import type { LoadedFile } from "../types";
 
 type Props = {
   files: LoadedFile[];
   onAddFiles: (files: FileList) => void;
   onRemove: (id: number) => void;
-  onMove: (id: number, dir: -1 | 1) => void;
+  onReorder: (id: number, insertBefore: number) => void;
 };
 
-export function FileList({ files, onAddFiles, onRemove, onMove }: Props) {
+export function FileList({ files, onAddFiles, onRemove, onReorder }: Props) {
+  const [draggingId, setDraggingId] = useState<number | null>(null);
+  const [insertBefore, setInsertBefore] = useState<number | null>(null);
+
+  const clearDrag = () => {
+    setDraggingId(null);
+    setInsertBefore(null);
+  };
+
+  const handleDragOver = (e: React.DragEvent, index: number) => {
+    if (draggingId === null) return;
+    e.preventDefault();
+    const rect = e.currentTarget.getBoundingClientRect();
+    const after = e.clientY > rect.top + rect.height / 2;
+    setInsertBefore(after ? index + 1 : index);
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    if (draggingId !== null && insertBefore !== null) {
+      onReorder(draggingId, insertBefore);
+    }
+    clearDrag();
+  };
+
   return (
     <div id="fileList">
       <ul>
         {files.map((file, i) => (
-          <li key={file.id}>
-            <span className="file-name">{file.name}</span>
-            <span className="file-actions">
-              <button
-                type="button"
-                onClick={() => onMove(file.id, -1)}
-                disabled={i === 0}
-                title="上へ移動"
-                aria-label={`${file.name} を上へ移動`}
-              >
-                ▲
-              </button>
-              <button
-                type="button"
-                onClick={() => onMove(file.id, 1)}
-                disabled={i === files.length - 1}
-                title="下へ移動"
-                aria-label={`${file.name} を下へ移動`}
-              >
-                ▼
-              </button>
-              <button
-                type="button"
-                onClick={() => onRemove(file.id)}
-                title="削除"
-                aria-label={`${file.name} を削除`}
-              >
-                ✕
-              </button>
+          <li
+            key={file.id}
+            draggable
+            onDragStart={(e) => {
+              setDraggingId(file.id);
+              e.dataTransfer.effectAllowed = "move";
+            }}
+            onDragOver={(e) => handleDragOver(e, i)}
+            onDrop={handleDrop}
+            onDragEnd={clearDrag}
+            className={
+              (draggingId === file.id ? "dragging" : "") +
+              (insertBefore === i ? " drop-before" : "") +
+              (insertBefore === i + 1 ? " drop-after" : "")
+            }
+          >
+            <span className="file-handle" aria-hidden="true">
+              ⠿
             </span>
+            <span className="file-name">{file.name}</span>
+            <button
+              type="button"
+              onClick={() => onRemove(file.id)}
+              title="削除"
+              aria-label={`${file.name} を削除`}
+            >
+              ✕
+            </button>
           </li>
         ))}
       </ul>

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -1,0 +1,62 @@
+import type { LoadedFile } from "../types";
+
+type Props = {
+  files: LoadedFile[];
+  onAddFiles: (files: FileList) => void;
+  onRemove: (id: number) => void;
+  onMove: (id: number, dir: -1 | 1) => void;
+};
+
+export function FileList({ files, onAddFiles, onRemove, onMove }: Props) {
+  return (
+    <div id="fileList">
+      <ul>
+        {files.map((file, i) => (
+          <li key={file.id}>
+            <span className="file-name">{file.name}</span>
+            <span className="file-actions">
+              <button
+                type="button"
+                onClick={() => onMove(file.id, -1)}
+                disabled={i === 0}
+                title="上へ移動"
+                aria-label={`${file.name} を上へ移動`}
+              >
+                ▲
+              </button>
+              <button
+                type="button"
+                onClick={() => onMove(file.id, 1)}
+                disabled={i === files.length - 1}
+                title="下へ移動"
+                aria-label={`${file.name} を下へ移動`}
+              >
+                ▼
+              </button>
+              <button
+                type="button"
+                onClick={() => onRemove(file.id)}
+                title="削除"
+                aria-label={`${file.name} を削除`}
+              >
+                ✕
+              </button>
+            </span>
+          </li>
+        ))}
+      </ul>
+      <label className="file-add">
+        ＋ ファイルを追加
+        <input
+          type="file"
+          accept=".txt"
+          multiple
+          onChange={(e) => {
+            if (e.target.files?.length) onAddFiles(e.target.files);
+            e.target.value = "";
+          }}
+        />
+      </label>
+    </div>
+  );
+}

--- a/src/components/ScriptSummary.tsx
+++ b/src/components/ScriptSummary.tsx
@@ -1,14 +1,19 @@
 import type { ParseWarning } from "../lib/parseScript";
+import type { LoadedFile } from "../types";
 import { CharacterFilter } from "./CharacterFilter";
 import { DialogueCount } from "./DialogueCount";
+import { FileList } from "./FileList";
 import { FileTitle } from "./FileTitle";
 import { ScriptWarnings } from "./ScriptWarnings";
 
 type Props = {
   title: string;
-  fileLoaded: boolean;
+  files: LoadedFile[];
   onTitleChange: (value: string) => void;
-  onFile: (file: File) => void;
+  onLoadFiles: (files: FileList) => void;
+  onAddFiles: (files: FileList) => void;
+  onRemoveFile: (id: number) => void;
+  onMoveFile: (id: number, dir: -1 | 1) => void;
   characters: string[];
   selected: Set<string>;
   onToggleCharacter: (character: string) => void;
@@ -19,9 +24,12 @@ type Props = {
 
 export function ScriptSummary({
   title,
-  fileLoaded,
+  files,
   onTitleChange,
-  onFile,
+  onLoadFiles,
+  onAddFiles,
+  onRemoveFile,
+  onMoveFile,
   characters,
   selected,
   onToggleCharacter,
@@ -29,6 +37,8 @@ export function ScriptSummary({
   warnings,
   error,
 }: Props) {
+  const fileLoaded = files.length > 0;
+
   return (
     <div id="scriptSummary">
       <h1>
@@ -37,9 +47,9 @@ export function ScriptSummary({
             type="file"
             id="fileInput"
             accept=".txt"
+            multiple
             onChange={(e) => {
-              const file = e.target.files?.[0];
-              if (file) onFile(file);
+              if (e.target.files?.length) onLoadFiles(e.target.files);
             }}
           />
         )}
@@ -49,6 +59,14 @@ export function ScriptSummary({
         <p id="fileError" role="alert">
           {error}
         </p>
+      )}
+      {fileLoaded && (
+        <FileList
+          files={files}
+          onAddFiles={onAddFiles}
+          onRemove={onRemoveFile}
+          onMove={onMoveFile}
+        />
       )}
       <CharacterFilter
         characters={characters}

--- a/src/components/ScriptSummary.tsx
+++ b/src/components/ScriptSummary.tsx
@@ -13,7 +13,7 @@ type Props = {
   onLoadFiles: (files: FileList) => void;
   onAddFiles: (files: FileList) => void;
   onRemoveFile: (id: number) => void;
-  onMoveFile: (id: number, dir: -1 | 1) => void;
+  onReorderFile: (id: number, insertBefore: number) => void;
   characters: string[];
   selected: Set<string>;
   onToggleCharacter: (character: string) => void;
@@ -29,7 +29,7 @@ export function ScriptSummary({
   onLoadFiles,
   onAddFiles,
   onRemoveFile,
-  onMoveFile,
+  onReorderFile,
   characters,
   selected,
   onToggleCharacter,
@@ -65,7 +65,7 @@ export function ScriptSummary({
           files={files}
           onAddFiles={onAddFiles}
           onRemove={onRemoveFile}
-          onMove={onMoveFile}
+          onReorder={onReorderFile}
         />
       )}
       <CharacterFilter

--- a/src/index.css
+++ b/src/index.css
@@ -179,7 +179,23 @@ button.character-dialogue:disabled {
       display: flex;
       align-items: center;
       gap: 6px;
-      padding: 2px 0;
+      padding: 3px 0;
+      cursor: grab;
+    }
+    li.dragging {
+      opacity: 0.4;
+    }
+    li.drop-before {
+      box-shadow: 0 -2px 0 0 var(--highlight-color);
+    }
+    li.drop-after {
+      box-shadow: 0 2px 0 0 var(--highlight-color);
+    }
+    .file-handle {
+      flex-shrink: 0;
+      color: var(--highlight-color);
+      opacity: 0.6;
+      line-height: 1;
     }
     .file-name {
       flex: 1;
@@ -187,12 +203,8 @@ button.character-dialogue:disabled {
       text-overflow: ellipsis;
       white-space: nowrap;
     }
-    .file-actions {
-      display: flex;
-      gap: 2px;
+    li button {
       flex-shrink: 0;
-    }
-    .file-actions button {
       width: 22px;
       height: 22px;
       padding: 0;
@@ -204,11 +216,7 @@ button.character-dialogue:disabled {
       line-height: 1;
       cursor: pointer;
     }
-    .file-actions button:disabled {
-      opacity: 0.3;
-      cursor: default;
-    }
-    .file-actions button:not(:disabled):hover {
+    li button:hover {
       background: var(--highlight-color);
       color: white;
     }

--- a/src/index.css
+++ b/src/index.css
@@ -162,6 +162,69 @@ button.character-dialogue:disabled {
       color: #333;
     }
   }
+  #fileList {
+    writing-mode: horizontal-tb;
+    font-family: var(--font-sans);
+    font-size: 10pt;
+    color: var(--highlight-color);
+    margin-top: 8px;
+    max-width: 280px;
+
+    ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }
+    li {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 2px 0;
+    }
+    .file-name {
+      flex: 1;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .file-actions {
+      display: flex;
+      gap: 2px;
+      flex-shrink: 0;
+    }
+    .file-actions button {
+      width: 22px;
+      height: 22px;
+      padding: 0;
+      border: 1px solid var(--highlight-color);
+      border-radius: 4px;
+      background: white;
+      color: var(--highlight-color);
+      font-size: 10px;
+      line-height: 1;
+      cursor: pointer;
+    }
+    .file-actions button:disabled {
+      opacity: 0.3;
+      cursor: default;
+    }
+    .file-actions button:not(:disabled):hover {
+      background: var(--highlight-color);
+      color: white;
+    }
+    .file-add {
+      display: inline-block;
+      margin-top: 6px;
+      padding: 2px 8px;
+      border: 1px dashed var(--highlight-color);
+      border-radius: 4px;
+      color: var(--highlight-color);
+      cursor: pointer;
+    }
+    .file-add input {
+      display: none;
+    }
+  }
   label {
     padding: var(--filter-label-padding);
     margin-block: var(--filter-label-margin);
@@ -233,6 +296,9 @@ button.character-dialogue:disabled {
     position: static;
   }
   #scriptWarnings {
+    display: none;
+  }
+  #fileList {
     display: none;
   }
   #floatingActions {

--- a/src/lib/loadedFiles.test.ts
+++ b/src/lib/loadedFiles.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import {
+  combineContents,
+  deriveTitle,
+  moveFile,
+  removeFile,
+} from "./loadedFiles";
+import type { LoadedFile } from "../types";
+
+const f = (id: number, name: string, content: string): LoadedFile => ({
+  id,
+  name,
+  content,
+});
+
+describe("combineContents", () => {
+  it("生テキストを改行で連結する", () => {
+    const files = [f(0, "a.txt", "田中「A」"), f(1, "b.txt", "山田「B」")];
+    expect(combineContents(files)).toBe("田中「A」\n山田「B」");
+  });
+
+  it("空配列は空文字", () => {
+    expect(combineContents([])).toBe("");
+  });
+});
+
+describe("deriveTitle", () => {
+  it(".txt を除いたファイル名を + で連結する", () => {
+    const files = [f(0, "第1幕.txt", ""), f(1, "第2幕.txt", "")];
+    expect(deriveTitle(files)).toBe("第1幕 + 第2幕");
+  });
+
+  it("拡張子がなければそのまま使う", () => {
+    expect(deriveTitle([f(0, "台本", "")])).toBe("台本");
+  });
+});
+
+describe("moveFile", () => {
+  const files = [f(0, "a", ""), f(1, "b", ""), f(2, "c", "")];
+
+  it("上に移動する", () => {
+    expect(moveFile(files, 1, -1).map((x) => x.id)).toEqual([1, 0, 2]);
+  });
+
+  it("下に移動する", () => {
+    expect(moveFile(files, 1, 1).map((x) => x.id)).toEqual([0, 2, 1]);
+  });
+
+  it("先頭をさらに上へは動かさない", () => {
+    expect(moveFile(files, 0, -1)).toBe(files);
+  });
+
+  it("末尾をさらに下へは動かさない", () => {
+    expect(moveFile(files, 2, 1)).toBe(files);
+  });
+
+  it("存在しない id は無変更", () => {
+    expect(moveFile(files, 99, -1)).toBe(files);
+  });
+});
+
+describe("removeFile", () => {
+  it("指定 id を取り除く", () => {
+    const files = [f(0, "a", ""), f(1, "b", ""), f(2, "c", "")];
+    expect(removeFile(files, 1).map((x) => x.id)).toEqual([0, 2]);
+  });
+});

--- a/src/lib/loadedFiles.test.ts
+++ b/src/lib/loadedFiles.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   combineContents,
   deriveTitle,
-  moveFile,
+  reorderFiles,
   removeFile,
 } from "./loadedFiles";
 import type { LoadedFile } from "../types";
@@ -35,27 +35,28 @@ describe("deriveTitle", () => {
   });
 });
 
-describe("moveFile", () => {
+describe("reorderFiles", () => {
   const files = [f(0, "a", ""), f(1, "b", ""), f(2, "c", "")];
 
-  it("上に移動する", () => {
-    expect(moveFile(files, 1, -1).map((x) => x.id)).toEqual([1, 0, 2]);
+  it("先頭を中間（c の直前）へ移動する", () => {
+    expect(reorderFiles(files, 0, 2).map((x) => x.id)).toEqual([1, 0, 2]);
   });
 
-  it("下に移動する", () => {
-    expect(moveFile(files, 1, 1).map((x) => x.id)).toEqual([0, 2, 1]);
+  it("末尾を先頭へ移動する", () => {
+    expect(reorderFiles(files, 2, 0).map((x) => x.id)).toEqual([2, 0, 1]);
   });
 
-  it("先頭をさらに上へは動かさない", () => {
-    expect(moveFile(files, 0, -1)).toBe(files);
+  it("先頭を末尾（length）へ移動する", () => {
+    expect(reorderFiles(files, 0, 3).map((x) => x.id)).toEqual([1, 2, 0]);
   });
 
-  it("末尾をさらに下へは動かさない", () => {
-    expect(moveFile(files, 2, 1)).toBe(files);
+  it("自分の直前・直後へのドロップは無変更", () => {
+    expect(reorderFiles(files, 1, 1).map((x) => x.id)).toEqual([0, 1, 2]);
+    expect(reorderFiles(files, 1, 2).map((x) => x.id)).toEqual([0, 1, 2]);
   });
 
-  it("存在しない id は無変更", () => {
-    expect(moveFile(files, 99, -1)).toBe(files);
+  it("存在しない id は同一参照を返す", () => {
+    expect(reorderFiles(files, 99, 0)).toBe(files);
   });
 });
 

--- a/src/lib/loadedFiles.ts
+++ b/src/lib/loadedFiles.ts
@@ -1,0 +1,30 @@
+import type { LoadedFile } from "../types";
+
+/** 複数ファイルを 1 本の台本として扱うため、生テキストを改行で連結する */
+export function combineContents(files: LoadedFile[]): string {
+  return files.map((f) => f.content).join("\n");
+}
+
+/** ファイル名（.txt を除く）を連結して既定のタイトルを作る */
+export function deriveTitle(files: LoadedFile[]): string {
+  return files.map((f) => f.name.replace(/\.txt$/i, "")).join(" + ");
+}
+
+/** id のファイルを dir 方向（-1 上 / +1 下）に 1 つ入れ替えた新しい配列を返す */
+export function moveFile(
+  files: LoadedFile[],
+  id: number,
+  dir: -1 | 1,
+): LoadedFile[] {
+  const i = files.findIndex((f) => f.id === id);
+  const j = i + dir;
+  if (i < 0 || j < 0 || j >= files.length) return files;
+  const next = [...files];
+  [next[i], next[j]] = [next[j], next[i]];
+  return next;
+}
+
+/** id のファイルを取り除いた新しい配列を返す */
+export function removeFile(files: LoadedFile[], id: number): LoadedFile[] {
+  return files.filter((f) => f.id !== id);
+}

--- a/src/lib/loadedFiles.ts
+++ b/src/lib/loadedFiles.ts
@@ -10,17 +10,22 @@ export function deriveTitle(files: LoadedFile[]): string {
   return files.map((f) => f.name.replace(/\.txt$/i, "")).join(" + ");
 }
 
-/** id のファイルを dir 方向（-1 上 / +1 下）に 1 つ入れ替えた新しい配列を返す */
-export function moveFile(
+/**
+ * id のファイルを「元の配列の insertBefore 番目の直前」へ移動した新しい配列を返す。
+ * insertBefore は 0〜files.length（末尾に置く場合は files.length）。
+ */
+export function reorderFiles(
   files: LoadedFile[],
   id: number,
-  dir: -1 | 1,
+  insertBefore: number,
 ): LoadedFile[] {
-  const i = files.findIndex((f) => f.id === id);
-  const j = i + dir;
-  if (i < 0 || j < 0 || j >= files.length) return files;
+  const from = files.findIndex((f) => f.id === id);
+  if (from < 0) return files;
   const next = [...files];
-  [next[i], next[j]] = [next[j], next[i]];
+  const [moved] = next.splice(from, 1);
+  // 自分より前の要素を抜いた分、挿入位置が 1 つ手前にずれる
+  const dest = from < insertBefore ? insertBefore - 1 : insertBefore;
+  next.splice(dest, 0, moved);
   return next;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,10 @@
+export type LoadedFile = {
+  id: number;
+  name: string;
+  /** ファイルの生テキスト。複数ファイルはこれを改行で連結して 1 本の台本として扱う */
+  content: string;
+};
+
 export type Dialogue = {
   id: number;
   character: string;


### PR DESCRIPTION
## 概要

複数の txt ファイルを読み込み、その全体を 1 本の台本として仮想的に扱う機能を追加しました。各ファイルの生テキストを改行で連結し、既存の `parseScript` にそのまま渡すことで、キャラ抽出・件数集計・連番・txt 書き出し・印刷はすべて従来どおり機能します。

## 機能

- 初回読み込みは複数選択に対応（`multiple`）
- サマリに「ファイル一覧」を追加。行をドラッグして並び替え、✕ で削除、「＋ ファイルを追加」で後から追加読み込み
- タイトルは初回読み込み時に各ファイル名（.txt 除く）を「 + 」で連結した既定値を入れる（以降の手編集は尊重し自動上書きしない）
- ファイル一覧は印刷時に非表示

## 並び替え（HTML5 ドラッグ）

- 各ファイル行を `draggable` にし、ブラウザ標準のドラッグで並び替える（追加依存なし）
- `onDragOver` でポインタが行の上半分か下半分かを判定し、挿入位置に 2px のラインを表示。掴んでいる行は薄く表示する
- スマホからは操作しない前提のため、上下ボタンは設けず削除・追加のみ
- 並び替えロジックは任意位置移動の純粋関数 `reorderFiles(id, insertBefore)` に集約

## 設計のポイント

- 連結・タイトル生成・並び替え・削除のロジックは `src/lib/loadedFiles.ts` の純粋関数（`combineContents` / `deriveTitle` / `reorderFiles` / `removeFile`）に集約し、Vitest でカバー
- `dialogues` / `characters` / `warnings` は `files` から `useMemo` で導出する派生状態に変更
- 「ボイス不要」マークはセリフの位置（id）に紐づくため、並び替え・削除では id がずれることからリセット。追加読み込みは既存セリフの id が不変なので維持する

## 確認

- `pnpm typecheck` / `pnpm lint` / `pnpm test:run`（61 passed）/ `pnpm build` すべて green

🤖 Generated with [Claude Code](https://claude.com/claude-code)