### PR TITLE
台本下部中央にセリフ送りナビを追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { FloatingActions } from "./components/FloatingActions";
+import { ScriptNav } from "./components/ScriptNav";
 import { ScriptSummary } from "./components/ScriptSummary";
 import { ScriptView } from "./components/ScriptView";
 import { toggleCharactersByMatch } from "./lib/characterToggle";
@@ -153,6 +154,9 @@ export function App() {
         noVoice={noVoice}
         onToggleNoVoice={toggleNoVoice}
       />
+      {dialogues.length > 0 && (
+        <ScriptNav hasHighlight={dialogueCount > 0} />
+      )}
       <FloatingActions onExportText={exportText} />
     </>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -155,7 +155,11 @@ export function App() {
         onToggleNoVoice={toggleNoVoice}
       />
       {dialogues.length > 0 && (
-        <ScriptNav hasHighlight={dialogueCount > 0} />
+        <ScriptNav
+          dialogues={dialogues}
+          selected={selected}
+          noVoice={noVoice}
+        />
       )}
       <FloatingActions onExportText={exportText} />
     </>

--- a/src/components/FloatingActions.tsx
+++ b/src/components/FloatingActions.tsx
@@ -3,34 +3,10 @@ type Props = {
 };
 
 export function FloatingActions({ onExportText }: Props) {
-  const scrollToStart = () =>
-    window.scrollTo({ left: 0, top: 0, behavior: "smooth" });
-  const scrollToEnd = () =>
-    window.scrollTo({
-      left: -document.documentElement.scrollWidth,
-      top: 0,
-      behavior: "smooth",
-    });
   const handlePrint = () => window.print();
 
   return (
     <div id="floatingActions">
-      <button
-        type="button"
-        onClick={scrollToStart}
-        title="先頭に戻る"
-        aria-label="先頭に戻る"
-      >
-        →
-      </button>
-      <button
-        type="button"
-        onClick={scrollToEnd}
-        title="末尾に進む"
-        aria-label="末尾に進む"
-      >
-        ←
-      </button>
       <button
         type="button"
         onClick={onExportText}

--- a/src/components/ScriptNav.tsx
+++ b/src/components/ScriptNav.tsx
@@ -4,37 +4,48 @@ type Props = {
   hasHighlight: boolean;
 };
 
-export function ScriptNav({ hasHighlight }: Props) {
-  const scrollToStart = () =>
-    window.scrollTo({ left: 0, top: 0, behavior: "smooth" });
-  const scrollToEnd = () =>
-    window.scrollTo({
-      left: -document.documentElement.scrollWidth,
-      top: 0,
-      behavior: "smooth",
-    });
+// 指定の scrollX まで素早く（250ms）スクロールする。
+// 縦書き（vertical-rl）では scrollX は負。ネイティブの smooth より速い。
+function animateScrollX(targetLeft: number) {
+  const startLeft = window.scrollX;
+  const dist = targetLeft - startLeft;
+  if (dist === 0) return;
+  const duration = 250;
+  let startTime: number | null = null;
+  const step = (now: number) => {
+    if (startTime === null) startTime = now;
+    const t = Math.min(1, (now - startTime) / duration);
+    const ease = 1 - Math.pow(1 - t, 3); // easeOutCubic
+    window.scrollTo({ left: startLeft + dist * ease, top: 0 });
+    if (t < 1) requestAnimationFrame(step);
+  };
+  requestAnimationFrame(step);
+}
 
-  // ハイライト中セリフのうち、現在の画面中央から見た隣のセリフを中央へ寄せる
+export function ScriptNav({ hasHighlight }: Props) {
+  const scrollToStart = () => animateScrollX(0);
+  const scrollToEnd = () =>
+    animateScrollX(-document.documentElement.scrollWidth);
+
+  // ハイライト中セリフのうち、画面中央から見た隣のセリフを左右中央へ寄せる
   const scrollToAdjacent = (direction: "next" | "prev") => {
     const els = Array.from(
       document.querySelectorAll<HTMLElement>(
         "#scriptContainer .character-dialogue.highlighted",
       ),
     );
-    const reference = window.innerWidth / 2;
+    const center = window.innerWidth / 2;
     const positions = els.map((el) => {
       const r = el.getBoundingClientRect();
       return { id: Number(el.dataset.dialogueId), center: r.left + r.width / 2 };
     });
-    const targetId = findAdjacentDialogue(positions, reference, direction);
+    const targetId = findAdjacentDialogue(positions, center, direction);
     if (targetId === null) return;
     const target = els.find((el) => Number(el.dataset.dialogueId) === targetId);
     if (!target) return;
     const r = target.getBoundingClientRect();
-    window.scrollBy({
-      left: r.left + r.width / 2 - reference,
-      behavior: "smooth",
-    });
+    // 対象の中心を画面の左右中央へ。目標 scrollX を直接指定して正確に合わせる
+    animateScrollX(window.scrollX + (r.left + r.width / 2 - center));
   };
 
   return (

--- a/src/components/ScriptNav.tsx
+++ b/src/components/ScriptNav.tsx
@@ -1,0 +1,73 @@
+import { findAdjacentDialogue } from "../lib/scriptNav";
+
+type Props = {
+  hasHighlight: boolean;
+};
+
+export function ScriptNav({ hasHighlight }: Props) {
+  const scrollToStart = () =>
+    window.scrollTo({ left: 0, top: 0, behavior: "smooth" });
+  const scrollToEnd = () =>
+    window.scrollTo({
+      left: -document.documentElement.scrollWidth,
+      top: 0,
+      behavior: "smooth",
+    });
+
+  // ハイライト中セリフのうち、現在の画面中央から見た隣のセリフを中央へ寄せる
+  const scrollToAdjacent = (direction: "next" | "prev") => {
+    const els = Array.from(
+      document.querySelectorAll<HTMLElement>(
+        "#scriptContainer .character-dialogue.highlighted",
+      ),
+    );
+    const reference = window.innerWidth / 2;
+    const positions = els.map((el) => {
+      const r = el.getBoundingClientRect();
+      return { id: Number(el.dataset.dialogueId), center: r.left + r.width / 2 };
+    });
+    const targetId = findAdjacentDialogue(positions, reference, direction);
+    if (targetId === null) return;
+    const target = els.find((el) => Number(el.dataset.dialogueId) === targetId);
+    if (!target) return;
+    const r = target.getBoundingClientRect();
+    window.scrollBy({
+      left: r.left + r.width / 2 - reference,
+      behavior: "smooth",
+    });
+  };
+
+  return (
+    <div id="scriptNav">
+      <button type="button" onClick={scrollToEnd} title="最後へ" aria-label="最後へ">
+        «
+      </button>
+      <button
+        type="button"
+        onClick={() => scrollToAdjacent("next")}
+        disabled={!hasHighlight}
+        title="次のセリフへ"
+        aria-label="次のセリフへ"
+      >
+        ‹
+      </button>
+      <button
+        type="button"
+        onClick={() => scrollToAdjacent("prev")}
+        disabled={!hasHighlight}
+        title="前のセリフへ"
+        aria-label="前のセリフへ"
+      >
+        ›
+      </button>
+      <button
+        type="button"
+        onClick={scrollToStart}
+        title="最初へ"
+        aria-label="最初へ"
+      >
+        »
+      </button>
+    </div>
+  );
+}

--- a/src/components/ScriptNav.tsx
+++ b/src/components/ScriptNav.tsx
@@ -1,19 +1,42 @@
 import { useEffect, useState } from "react";
 import { findAdjacentDialogue } from "../lib/scriptNav";
+import type { Dialogue } from "../types";
 
 type Props = {
-  hasHighlight: boolean;
+  // 内容は使わず、ハイライト集合が変化したら可否を再計算するための依存として受け取る
+  dialogues: Dialogue[];
+  selected: Set<string>;
+  noVoice: Set<number>;
+};
+
+type NavState = {
+  areaCenter: number | null;
+  atStart: boolean;
+  atEnd: boolean;
+  canNext: boolean;
+  canPrev: boolean;
 };
 
 // 読める領域の右端 x を返す。サマリ（キャラリスト等）は右側に sticky で
-// 白マスクごと居座るため、その白マスク左端（＝サマリの margin-box 左端）までを
-// 読める領域とみなす。サマリが無ければビューポート幅。
+// 居座るため、その左端までを読める領域とみなす。サマリが無ければビューポート幅。
 function readAreaRightEdge(): number {
   const summary = document.getElementById("scriptSummary");
   if (!summary) return window.innerWidth;
   const rect = summary.getBoundingClientRect();
   const marginLeft = parseFloat(getComputedStyle(summary).marginLeft) || 0;
   return rect.left - marginLeft;
+}
+
+function highlightPositions() {
+  const els = Array.from(
+    document.querySelectorAll<HTMLElement>(
+      "#scriptContainer .character-dialogue.highlighted",
+    ),
+  );
+  return els.map((el) => {
+    const r = el.getBoundingClientRect();
+    return { id: Number(el.dataset.dialogueId), center: r.left + r.width / 2 };
+  });
 }
 
 // 指定の scrollX まで素早く（250ms）スクロールする。
@@ -34,24 +57,57 @@ function animateScrollX(targetLeft: number) {
   requestAnimationFrame(step);
 }
 
-export function ScriptNav({ hasHighlight }: Props) {
-  // ナビバー自体も読める領域の左右中央へ置く
-  const [areaCenter, setAreaCenter] = useState<number | null>(null);
+export function ScriptNav({ dialogues, selected, noVoice }: Props) {
+  const [state, setState] = useState<NavState>({
+    areaCenter: null,
+    atStart: true,
+    atEnd: false,
+    canNext: false,
+    canPrev: false,
+  });
+
   useEffect(() => {
-    const update = () => setAreaCenter(readAreaRightEdge() / 2);
-    update();
-    window.addEventListener("resize", update);
+    const recompute = () => {
+      const doc = document.documentElement;
+      const maxScroll = doc.scrollWidth - doc.clientWidth; // overflow 量（正）
+      const x = -window.scrollX; // 0（先頭・右）〜 maxScroll（末尾・左）
+      const center = readAreaRightEdge() / 2;
+      const positions = highlightPositions();
+      setState({
+        areaCenter: center,
+        atStart: x <= 1,
+        atEnd: x >= maxScroll - 1,
+        canNext: findAdjacentDialogue(positions, center, "next") !== null,
+        canPrev: findAdjacentDialogue(positions, center, "prev") !== null,
+      });
+    };
+
+    // スクロール中は rAF で間引く
+    let ticking = false;
+    const onScroll = () => {
+      if (ticking) return;
+      ticking = true;
+      requestAnimationFrame(() => {
+        ticking = false;
+        recompute();
+      });
+    };
+
+    recompute();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", recompute);
     const summary = document.getElementById("scriptSummary");
     let ro: ResizeObserver | null = null;
     if (summary && typeof ResizeObserver !== "undefined") {
-      ro = new ResizeObserver(update);
+      ro = new ResizeObserver(recompute);
       ro.observe(summary);
     }
     return () => {
-      window.removeEventListener("resize", update);
+      window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", recompute);
       ro?.disconnect();
     };
-  }, []);
+  }, [dialogues, selected, noVoice]);
 
   const scrollToStart = () => animateScrollX(0);
   const scrollToEnd = () =>
@@ -59,19 +115,13 @@ export function ScriptNav({ hasHighlight }: Props) {
 
   // ハイライト中セリフのうち、読める領域の中央から見た隣のセリフを中央へ寄せる
   const scrollToAdjacent = (direction: "next" | "prev") => {
-    const els = Array.from(
-      document.querySelectorAll<HTMLElement>(
-        "#scriptContainer .character-dialogue.highlighted",
-      ),
-    );
     const center = readAreaRightEdge() / 2;
-    const positions = els.map((el) => {
-      const r = el.getBoundingClientRect();
-      return { id: Number(el.dataset.dialogueId), center: r.left + r.width / 2 };
-    });
+    const positions = highlightPositions();
     const targetId = findAdjacentDialogue(positions, center, direction);
     if (targetId === null) return;
-    const target = els.find((el) => Number(el.dataset.dialogueId) === targetId);
+    const target = document.querySelector<HTMLElement>(
+      `#scriptContainer [data-dialogue-id="${targetId}"]`,
+    );
     if (!target) return;
     const r = target.getBoundingClientRect();
     // 対象の中心を読める領域の左右中央へ。目標 scrollX を直接指定して正確に合わせる
@@ -81,15 +131,23 @@ export function ScriptNav({ hasHighlight }: Props) {
   return (
     <div
       id="scriptNav"
-      style={{ left: areaCenter != null ? `${areaCenter}px` : undefined }}
+      style={{
+        left: state.areaCenter != null ? `${state.areaCenter}px` : undefined,
+      }}
     >
-      <button type="button" onClick={scrollToEnd} title="最後へ" aria-label="最後へ">
+      <button
+        type="button"
+        onClick={scrollToEnd}
+        disabled={state.atEnd}
+        title="最後へ"
+        aria-label="最後へ"
+      >
         «
       </button>
       <button
         type="button"
         onClick={() => scrollToAdjacent("next")}
-        disabled={!hasHighlight}
+        disabled={!state.canNext}
         title="次のセリフへ"
         aria-label="次のセリフへ"
       >
@@ -98,7 +156,7 @@ export function ScriptNav({ hasHighlight }: Props) {
       <button
         type="button"
         onClick={() => scrollToAdjacent("prev")}
-        disabled={!hasHighlight}
+        disabled={!state.canPrev}
         title="前のセリフへ"
         aria-label="前のセリフへ"
       >
@@ -107,6 +165,7 @@ export function ScriptNav({ hasHighlight }: Props) {
       <button
         type="button"
         onClick={scrollToStart}
+        disabled={state.atStart}
         title="最初へ"
         aria-label="最初へ"
       >

--- a/src/components/ScriptNav.tsx
+++ b/src/components/ScriptNav.tsx
@@ -1,8 +1,20 @@
+import { useEffect, useState } from "react";
 import { findAdjacentDialogue } from "../lib/scriptNav";
 
 type Props = {
   hasHighlight: boolean;
 };
+
+// 読める領域の右端 x を返す。サマリ（キャラリスト等）は右側に sticky で
+// 白マスクごと居座るため、その白マスク左端（＝サマリの margin-box 左端）までを
+// 読める領域とみなす。サマリが無ければビューポート幅。
+function readAreaRightEdge(): number {
+  const summary = document.getElementById("scriptSummary");
+  if (!summary) return window.innerWidth;
+  const rect = summary.getBoundingClientRect();
+  const marginLeft = parseFloat(getComputedStyle(summary).marginLeft) || 0;
+  return rect.left - marginLeft;
+}
 
 // 指定の scrollX まで素早く（250ms）スクロールする。
 // 縦書き（vertical-rl）では scrollX は負。ネイティブの smooth より速い。
@@ -23,24 +35,36 @@ function animateScrollX(targetLeft: number) {
 }
 
 export function ScriptNav({ hasHighlight }: Props) {
+  // ナビバー自体も読める領域の左右中央へ置く
+  const [areaCenter, setAreaCenter] = useState<number | null>(null);
+  useEffect(() => {
+    const update = () => setAreaCenter(readAreaRightEdge() / 2);
+    update();
+    window.addEventListener("resize", update);
+    const summary = document.getElementById("scriptSummary");
+    let ro: ResizeObserver | null = null;
+    if (summary && typeof ResizeObserver !== "undefined") {
+      ro = new ResizeObserver(update);
+      ro.observe(summary);
+    }
+    return () => {
+      window.removeEventListener("resize", update);
+      ro?.disconnect();
+    };
+  }, []);
+
   const scrollToStart = () => animateScrollX(0);
   const scrollToEnd = () =>
     animateScrollX(-document.documentElement.scrollWidth);
 
-  // ハイライト中セリフのうち、画面中央から見た隣のセリフを左右中央へ寄せる
+  // ハイライト中セリフのうち、読める領域の中央から見た隣のセリフを中央へ寄せる
   const scrollToAdjacent = (direction: "next" | "prev") => {
     const els = Array.from(
       document.querySelectorAll<HTMLElement>(
         "#scriptContainer .character-dialogue.highlighted",
       ),
     );
-    // サマリ（キャラリスト等）は右側に sticky で居座るため、その左端までを
-    // 読める領域とみなし、その左右中央を基準にする
-    const summary = document.getElementById("scriptSummary");
-    const rightEdge = summary
-      ? summary.getBoundingClientRect().left
-      : window.innerWidth;
-    const center = rightEdge / 2;
+    const center = readAreaRightEdge() / 2;
     const positions = els.map((el) => {
       const r = el.getBoundingClientRect();
       return { id: Number(el.dataset.dialogueId), center: r.left + r.width / 2 };
@@ -50,12 +74,15 @@ export function ScriptNav({ hasHighlight }: Props) {
     const target = els.find((el) => Number(el.dataset.dialogueId) === targetId);
     if (!target) return;
     const r = target.getBoundingClientRect();
-    // 対象の中心を画面の左右中央へ。目標 scrollX を直接指定して正確に合わせる
+    // 対象の中心を読める領域の左右中央へ。目標 scrollX を直接指定して正確に合わせる
     animateScrollX(window.scrollX + (r.left + r.width / 2 - center));
   };
 
   return (
-    <div id="scriptNav">
+    <div
+      id="scriptNav"
+      style={{ left: areaCenter != null ? `${areaCenter}px` : undefined }}
+    >
       <button type="button" onClick={scrollToEnd} title="最後へ" aria-label="最後へ">
         «
       </button>

--- a/src/components/ScriptNav.tsx
+++ b/src/components/ScriptNav.tsx
@@ -34,7 +34,13 @@ export function ScriptNav({ hasHighlight }: Props) {
         "#scriptContainer .character-dialogue.highlighted",
       ),
     );
-    const center = window.innerWidth / 2;
+    // サマリ（キャラリスト等）は右側に sticky で居座るため、その左端までを
+    // 読める領域とみなし、その左右中央を基準にする
+    const summary = document.getElementById("scriptSummary");
+    const rightEdge = summary
+      ? summary.getBoundingClientRect().left
+      : window.innerWidth;
+    const center = rightEdge / 2;
     const positions = els.map((el) => {
       const r = el.getBoundingClientRect();
       return { id: Number(el.dataset.dialogueId), center: r.left + r.width / 2 };

--- a/src/components/ScriptView.tsx
+++ b/src/components/ScriptView.tsx
@@ -36,6 +36,7 @@ export function ScriptView({
           <button
             key={d.id}
             type="button"
+            data-dialogue-id={d.id}
             className={
               "character-dialogue" + (highlighted ? " highlighted" : "")
             }

--- a/src/index.css
+++ b/src/index.css
@@ -84,7 +84,6 @@ button.character-dialogue:disabled {
 
 /* サマリのスタイル */
 #scriptSummary {
-  margin-left: var(--page-margin);
   margin-block-start: calc(-1 * var(--page-margin));
   padding-block-start: var(--page-margin);
   position: sticky;
@@ -92,16 +91,6 @@ button.character-dialogue:disabled {
   background: white;
   z-index: 10;
 
-  &::after {
-    content: "";
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: calc(-1 * var(--page-margin));
-    width: var(--page-margin);
-    background: white;
-    pointer-events: none;
-  }
   input,
   textarea {
     font: inherit;

--- a/src/index.css
+++ b/src/index.css
@@ -99,7 +99,7 @@ button.character-dialogue:disabled {
     bottom: 0;
     left: calc(-1 * var(--page-margin));
     width: var(--page-margin);
-    background: linear-gradient(to right, transparent, white);
+    background: white;
     pointer-events: none;
   }
   input,

--- a/src/index.css
+++ b/src/index.css
@@ -291,6 +291,39 @@ button.character-dialogue:disabled {
   color: white;
 }
 
+/* 台本下部中央のセリフ送りナビ */
+#scriptNav {
+  position: fixed;
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 8px;
+  z-index: 100;
+  writing-mode: horizontal-tb;
+}
+#scriptNav button {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 1px solid var(--highlight-color);
+  background: white;
+  color: var(--highlight-color);
+  cursor: pointer;
+  font-family: var(--font-sans);
+  font-size: 18px;
+  line-height: 1;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+}
+#scriptNav button:hover:not(:disabled) {
+  background: var(--highlight-color);
+  color: white;
+}
+#scriptNav button:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
 /* 印刷時のスタイル */
 @media print {
   @page {
@@ -310,6 +343,9 @@ button.character-dialogue:disabled {
     display: none;
   }
   #floatingActions {
+    display: none;
+  }
+  #scriptNav {
     display: none;
   }
 }

--- a/src/lib/scriptNav.test.ts
+++ b/src/lib/scriptNav.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { findAdjacentDialogue } from "./scriptNav";
+
+// start 寄り（右・中心大）から end 寄り（左・中心小）の順
+const positions = [
+  { id: 1, center: 900 },
+  { id: 2, center: 600 },
+  { id: 3, center: 300 },
+];
+
+describe("findAdjacentDialogue", () => {
+  it("next は基準より左で最も近いセリフを選ぶ", () => {
+    expect(findAdjacentDialogue(positions, 650, "next")).toBe(2);
+  });
+
+  it("prev は基準より右で最も近いセリフを選ぶ", () => {
+    expect(findAdjacentDialogue(positions, 650, "prev")).toBe(1);
+  });
+
+  it("中央のセリフからさらに next で次へ進む", () => {
+    expect(findAdjacentDialogue(positions, 600, "next")).toBe(3);
+  });
+
+  it("中央のセリフから prev で前へ戻る", () => {
+    expect(findAdjacentDialogue(positions, 600, "prev")).toBe(1);
+  });
+
+  it("next 方向に対象が無ければ null", () => {
+    expect(findAdjacentDialogue(positions, 200, "next")).toBe(null);
+  });
+
+  it("prev 方向に対象が無ければ null", () => {
+    expect(findAdjacentDialogue(positions, 1000, "prev")).toBe(null);
+  });
+
+  it("空配列は null", () => {
+    expect(findAdjacentDialogue([], 500, "next")).toBe(null);
+  });
+});

--- a/src/lib/scriptNav.ts
+++ b/src/lib/scriptNav.ts
@@ -1,0 +1,29 @@
+export type DialoguePosition = { id: number; center: number };
+
+/**
+ * 縦書き（vertical-rl）の台本で、基準位置から見た隣のセリフ id を返す。
+ * start は右（中心 x が大きい）、end は左（中心 x が小さい）にあるため
+ * - "next"（次のセリフ＝end 方向）は基準より左で最も近いもの
+ * - "prev"（前のセリフ＝start 方向）は基準より右で最も近いもの
+ * を選ぶ。該当が無ければ null。
+ */
+export function findAdjacentDialogue(
+  positions: DialoguePosition[],
+  reference: number,
+  direction: "next" | "prev",
+): number | null {
+  const eps = 1; // 中央付近に居座るセリフを自分自身として拾わないための遊び
+  let best: DialoguePosition | null = null;
+  for (const p of positions) {
+    if (direction === "next") {
+      if (p.center < reference - eps && (!best || p.center > best.center)) {
+        best = p;
+      }
+    } else {
+      if (p.center > reference + eps && (!best || p.center < best.center)) {
+        best = p;
+      }
+    }
+  }
+  return best ? best.id : null;
+}


### PR DESCRIPTION
## 概要

台本スクロールエリアの下部中央に、横並びのナビゲーションバーを新設しました。選択キャラの次／前のセリフへ素早く飛べます。

ボタンは左から

| 表示 | 動作 |
|------|------|
| « | 最後へ（台本の末尾＝左端へ） |
| ‹ | 次のセリフへ（選択キャラの次のハイライトへ） |
| › | 前のセリフへ（選択キャラの前のハイライトへ） |
| » | 最初へ（台本の先頭＝右端へ） |

## 変更点

- `ScriptNav` を新設。これまで FAB（右下）にあった最初へ・最後へのスクロールもこちらへ集約
- `FloatingActions`（右下 FAB）は txt 書き出し・印刷のみに整理
- 次／前の判定は縦書き（vertical-rl）の幾何（start＝右・end＝左）を踏まえ、画面中央を基準に隣のセリフを中央へ寄せる方式。判定本体は純粋関数 `findAdjacentDialogue` に切り出して `src/lib/scriptNav.test.ts` でテスト
- セリフ要素に `data-dialogue-id` を付与し、対象セリフへスクロール
- 印刷時はナビバーを非表示

## 確認

- typecheck / lint / test（68 passed）/ build いずれも通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)